### PR TITLE
Update DBConnect.cs

### DIFF
--- a/EPadPw/Classes/DBConnect.cs
+++ b/EPadPw/Classes/DBConnect.cs
@@ -6,8 +6,25 @@ using System.Web.Configuration;
 
 namespace EPadPw.Classes
 {
-    public class DBConnect
+    //public class DBConnect
+    //{
+    //    public static object NoSqlConnection { get; } = WebConfigurationManager.AppSettings["NoSqlConnection"].ToString();
+    //}
+    /// <summary>
+    /// Provides access to database connection settings.
+    /// </summary>
+    public static class DBConnect
     {
-        public static object NoSqlConnection { get; } = WebConfigurationManager.AppSettings["NoSqlConnection"].ToString();
+        /// <summary>
+        /// Gets the connection string for the NoSqlConnection.
+        /// </summary>
+        public static string NoSqlConnection { get; }
+
+        // Static constructor to initialize the static property
+        static DBConnect()
+        {
+            // Retrieve connection string from web configuration
+            NoSqlConnection = WebConfigurationManager.AppSettings["NoSqlConnection"];
+        }
     }
 }


### PR DESCRIPTION
Refactor DBConnect class to improve maintainability.

1. The DBConnect class previously used a static object property to represent the database connection string.
2. This commit refactors the class to use a static string property instead, providing clearer intent and type safety.
3. A static constructor is added to initialize the NoSqlConnection property, improving code organization.
4. XML comments are also updated to provide clear documentation for each member of the class.